### PR TITLE
Migrate notifier from Slack to Telegram with TOTP auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,16 +63,20 @@ Single-file C program. Key design points:
 
 State file format (two tab-separated words): `started\t<reason>` or `stopped\t<reason>`.
 
-### `notifier/` — Slack notification service
+### `notifier/` — Telegram notification service
 
-Node.js script (`index.js`) that watches `/var/run/waterfuse/` with `fs.watch` and posts to Slack via `@slack/web-api` when the state file changes.
+Node.js script (`index.js`) that watches `/run/waterfuse/` with `fs.watch` and posts to a Telegram chat when the state file changes. Also supports bot commands via long polling.
 
-Required environment variables: `slackToken`, `slackChannel`.
+Required environment variables: `telegramToken` (bot token from BotFather), `telegramChatId` (numeric chat ID of the target chat).
 
 ```bash
 cd notifier
 npm install
-slackToken=xoxb-... slackChannel=C... node index.js
+telegramToken=123:ABC telegramChatId=-100... node index.js
 ```
 
-Note: the notifier currently has a bug — `stateFile` is hardcoded as `'waterfuse.state'` but the daemon writes to `/run/waterfuse/waterfuse.state`; the notifier watches `/var/run/waterfuse` (these resolve to the same path on most Linux systems via symlink, but is worth verifying on the target Pi).
+**Bot commands** (only accepted from the configured `telegramChatId`):
+- `/reset` — sends `SIGUSR1` to the daemon; clears the stop condition and restarts the pump
+- `/usage` — sends `SIGUSR2` to the daemon, tails the log to read `total_litres`, and reports accumulated pump run time
+
+Run-time tracking (`pumpStartTime`, `accumulatedRunMs`) is held in process memory; it seeds from the current state file at startup to survive restarts, but accumulated cross-session totals reset if the notifier is restarted.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Waterfuse is a Raspberry Pi water flow protection daemon. It monitors a flow meter via GPIO interrupt and cuts power to a water pump relay if flow exceeds configurable volume or time limits. A companion Node.js notifier posts state changes to Slack.
+
+## Build & Install
+
+```bash
+# Build
+make
+
+# Install (stops service, replaces binary, restarts service)
+make install
+```
+
+Depends on the `wiringPi` library (`-lwiringPi`). Must be built and run on a Raspberry Pi (or compatible wiringPi-supported board).
+
+## Running
+
+```bash
+# Run in foreground (don't daemonize)
+./waterfuse -d
+
+# Increase verbosity (repeat for higher levels; 3 is very chatty)
+./waterfuse -d -v -v -v
+
+# Override config at runtime
+./waterfuse -l <max_litres> -c <clicks_per_litre> -t <max_minutes> -r <reset_seconds>
+```
+
+When daemonized, logs go to `/var/log/waterfuse.log`. PID file: `/run/waterfuse/waterfuse.pid`. State file: `/run/waterfuse/waterfuse.state`.
+
+## Configuration
+
+Config file: `/etc/waterfuse/waterfuse.conf` — key/value pairs, one per line:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `clicks_per_litre` | 450 | Pulses from flow meter per litre |
+| `max_litres` | 200 | Volume limit before shutoff |
+| `max_time` | 15 (minutes) | Time limit before shutoff |
+| `reset_period` | 600 | Seconds of no-flow before counters reset |
+| `verbosity` | 0 | Log verbosity (0=minimal, 3=debug) |
+
+Config is re-read on `SIGHUP` (which also rolls the log).
+
+## Architecture
+
+### `waterfuse.c` — the main daemon
+
+Single-file C program. Key design points:
+
+- **GPIO pins** (wiringPi numbering): `FLOW_METER=0`, `POWER_RELAY=1`, `RESET_BUTTON=2`
+- **ISR** (`handleClick`): increments volatile `clicks` counter on each rising edge from the flow meter
+- **Main loop** (1 second tick): checks `clicks` delta against limits; drives the relay HIGH (pump on) or LOW (pump off)
+- **State machine**: `counting` tracks whether flow is active; `triggered` means the relay has been shut off and awaits a reset
+- **Reset sources**: physical button (polled, pin 2), `SIGUSR1` signal, or `reset=2` via `SIGUSR2`-adjacent logic
+- **Shutdown triggers**: exceed `max_litres` (reason: "volume") or exceed `time_limit` seconds of continuous flow (reason: "time")
+- **Signal handling**: `SIGHUP`=reopen log+reread config, `SIGUSR1`=reset pump on, `SIGUSR2`=print stats, `SIGCONT`=force pump off
+
+State file format (two tab-separated words): `started\t<reason>` or `stopped\t<reason>`.
+
+### `notifier/` — Slack notification service
+
+Node.js script (`index.js`) that watches `/var/run/waterfuse/` with `fs.watch` and posts to Slack via `@slack/web-api` when the state file changes.
+
+Required environment variables: `slackToken`, `slackChannel`.
+
+```bash
+cd notifier
+npm install
+slackToken=xoxb-... slackChannel=C... node index.js
+```
+
+Note: the notifier currently has a bug — `stateFile` is hardcoded as `'waterfuse.state'` but the daemon writes to `/run/waterfuse/waterfuse.state`; the notifier watches `/var/run/waterfuse` (these resolve to the same path on most Linux systems via symlink, but is worth verifying on the target Pi).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,18 +65,27 @@ State file format (two tab-separated words): `started\t<reason>` or `stopped\t<r
 
 ### `notifier/` — Telegram notification service
 
-Node.js script (`index.js`) that watches `/run/waterfuse/` with `fs.watch` and posts to a Telegram chat when the state file changes. Also supports bot commands via long polling.
+Node.js script (`index.js`) that watches `/run/waterfuse/` with `fs.watch` and broadcasts to all authorized Telegram chats when the state file changes. Commands are received via long polling.
 
-Required environment variables: `telegramToken` (bot token from BotFather), `telegramChatId` (numeric chat ID of the target chat).
+**Environment variables:**
+- `telegramToken` — bot token from BotFather (required)
+- `totpSecret` — base32-encoded TOTP secret shared with authorized users (required)
+- `authFile` — path to persist authorized chat IDs (default: `/etc/waterfuse/authorized_chats.json`)
 
 ```bash
+# Generate a TOTP secret
+node -e "const {Secret}=require('otpauth'); console.log(Secret.generate().base32)"
+
 cd notifier
 npm install
-telegramToken=123:ABC telegramChatId=-100... node index.js
+telegramToken=123:ABC totpSecret=BASE32SECRET node index.js
+# On startup, prints an otpauth:// URI — scan it with any authenticator app
 ```
 
-**Bot commands** (only accepted from the configured `telegramChatId`):
-- `/reset` — sends `SIGUSR1` to the daemon; clears the stop condition and restarts the pump
-- `/usage` — sends `SIGUSR2` to the daemon, tails the log to read `total_litres`, and reports accumulated pump run time
+**Bot commands:**
+- `/auth <code>` — validates a TOTP code; on success adds the sender to the authorized set (available to anyone)
+- `/deauth` — removes the sender from the authorized set
+- `/reset` — sends `SIGUSR1` to the daemon to clear the stop condition and restart the pump (authorized only)
+- `/usage` — sends `SIGUSR2` to the daemon, tails the log for `total_litres`, and reports accumulated pump run time (authorized only)
 
-Run-time tracking (`pumpStartTime`, `accumulatedRunMs`) is held in process memory; it seeds from the current state file at startup to survive restarts, but accumulated cross-session totals reset if the notifier is restarted.
+Unauthorized senders are silently ignored for all commands except `/auth`. Authorized chat IDs are persisted to `authFile` and loaded on startup. Run-time accumulation (`pumpStartTime`, `accumulatedRunMs`) seeds from the current state file on startup but resets if the notifier process is restarted.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Node.js script (`index.js`) that watches `/run/waterfuse/` with `fs.watch` and b
 
 ```bash
 # Generate a TOTP secret
-node -e "const {Secret}=require('otpauth'); console.log(Secret.generate().base32)"
+node -e "const {Secret}=require('otpauth'); const s=new Secret(); console.log(s.base32)"
 
 cd notifier
 npm install

--- a/notifier/index.js
+++ b/notifier/index.js
@@ -2,9 +2,14 @@
 
 const fs = require('fs')
 const path = require('path')
+const https = require('https')
 const { execSync } = require('child_process')
 const axios = require('axios')
 const { TOTP, Secret } = require('otpauth')
+
+// Force IPv4 — Node 18+ happy-eyeballs tries IPv6 first, which times out
+// on networks where IPv6 routing to api.telegram.org isn't available
+const httpsAgent = new https.Agent({ family: 4 })
 
 const telegramToken = process.env.telegramToken
 const totpSecret = process.env.totpSecret
@@ -31,6 +36,10 @@ const totp = new TOTP({
 // Print setup URI on startup so the admin can add it to authenticator apps
 console.log('Authenticator setup URI:', totp.toString())
 
+function errMsg(err) {
+  return err.message || err.code || String(err)
+}
+
 // ---- authorized chats -------------------------------------------------------
 
 let authorizedChats = new Set()
@@ -47,7 +56,7 @@ function saveAuth() {
   try {
     fs.writeFileSync(authFile, JSON.stringify([...authorizedChats]))
   } catch (err) {
-    console.error('Failed to save auth file:', err.message)
+    console.error('Failed to save auth file:', errMsg(err))
   }
 }
 
@@ -60,13 +69,13 @@ async function sendMessage(chatId, text) {
     chat_id: chatId,
     text,
     parse_mode: 'Markdown'
-  })
+  }, { httpsAgent })
 }
 
 async function broadcast(text) {
   for (const chatId of authorizedChats) {
     await sendMessage(chatId, text)
-      .catch(err => console.error(`Broadcast to ${chatId} failed:`, err.message))
+      .catch(err => console.error(`Broadcast to ${chatId} failed:`, errMsg(err)))
   }
 }
 
@@ -171,7 +180,7 @@ async function handleUpdate(update) {
       process.kill(getDaemonPid(), 'SIGUSR1')
       await sendMessage(chatId, 'Reset signal sent — pump should restart.')
     } catch (err) {
-      await sendMessage(chatId, `Reset failed: ${err.message}`)
+      await sendMessage(chatId, `Reset failed: ${errMsg(err)}`)
     }
     return
   }
@@ -191,7 +200,7 @@ async function handleUpdate(update) {
         `*Water Usage*\nTotal litres: ${litres} L\nPump run time: ${currentRuntime()}`
       )
     } catch (err) {
-      await sendMessage(chatId, `Usage query failed: ${err.message}`)
+      await sendMessage(chatId, `Usage query failed: ${errMsg(err)}`)
     }
     return
   }
@@ -203,14 +212,15 @@ async function poll() {
     try {
       const res = await axios.get(`${api}/getUpdates`, {
         params: { offset: pollOffset, timeout: 30 },
-        timeout: 35000
+        timeout: 35000,
+        httpsAgent
       })
       for (const update of res.data.result) {
         pollOffset = update.update_id + 1
-        handleUpdate(update).catch(err => console.error('Handler error:', err.message))
+        handleUpdate(update).catch(err => console.error('Handler error:', errMsg(err)))
       }
     } catch (err) {
-      console.error('Poll error:', err.message)
+      console.error('Poll error:', errMsg(err))
       await new Promise(resolve => setTimeout(resolve, 5000))
     }
   }

--- a/notifier/index.js
+++ b/notifier/index.js
@@ -4,23 +4,78 @@ const fs = require('fs')
 const path = require('path')
 const { execSync } = require('child_process')
 const axios = require('axios')
+const { TOTP, Secret } = require('otpauth')
 
-const token = process.env.telegramToken
-const chatId = process.env.telegramChatId
+const telegramToken = process.env.telegramToken
+const totpSecret = process.env.totpSecret
+const authFile = process.env.authFile || '/etc/waterfuse/authorized_chats.json'
 const stateDir = '/run/waterfuse'
 const stateFile = 'waterfuse.state'
 const pidFile = path.join(stateDir, 'waterfuse.pid')
 const logFile = '/var/log/waterfuse.log'
 
-const api = `https://api.telegram.org/bot${token}`
+if (!telegramToken || !totpSecret) {
+  console.error('telegramToken and totpSecret environment variables are required')
+  process.exit(1)
+}
+
+const api = `https://api.telegram.org/bot${telegramToken}`
 let pollOffset = 0
+
+const totp = new TOTP({
+  issuer: 'WaterFuse',
+  label: 'WaterFuse',
+  secret: Secret.fromBase32(totpSecret)
+})
+
+// Print setup URI on startup so the admin can add it to authenticator apps
+console.log('Authenticator setup URI:', totp.toString())
+
+// ---- authorized chats -------------------------------------------------------
+
+let authorizedChats = new Set()
+
+function loadAuth() {
+  try {
+    const data = JSON.parse(fs.readFileSync(authFile, 'utf8'))
+    authorizedChats = new Set(data)
+    console.log(`Loaded ${authorizedChats.size} authorized chat(s)`)
+  } catch (_) {}
+}
+
+function saveAuth() {
+  try {
+    fs.writeFileSync(authFile, JSON.stringify([...authorizedChats]))
+  } catch (err) {
+    console.error('Failed to save auth file:', err.message)
+  }
+}
+
+loadAuth()
+
+// ---- Telegram helpers -------------------------------------------------------
+
+async function sendMessage(chatId, text) {
+  await axios.post(`${api}/sendMessage`, {
+    chat_id: chatId,
+    text,
+    parse_mode: 'Markdown'
+  })
+}
+
+async function broadcast(text) {
+  for (const chatId of authorizedChats) {
+    await sendMessage(chatId, text)
+      .catch(err => console.error(`Broadcast to ${chatId} failed:`, err.message))
+  }
+}
+
+// ---- state tracking ---------------------------------------------------------
 
 let fileContents = ''
 let oldContents = ''
 let pumpStartTime = null   // Date.now() when pump last started
 let accumulatedRunMs = 0   // run time accrued from completed sessions
-
-// ---- helpers ----------------------------------------------------------------
 
 function formatDuration(ms) {
   const s = Math.floor(ms / 1000)
@@ -42,16 +97,6 @@ function getDaemonPid() {
   return parseInt(fs.readFileSync(pidFile, 'utf8').trim(), 10)
 }
 
-async function sendMessage(cid, text) {
-  await axios.post(`${api}/sendMessage`, {
-    chat_id: cid,
-    text,
-    parse_mode: 'Markdown'
-  })
-}
-
-// ---- state tracking ---------------------------------------------------------
-
 function applyState(contents) {
   const [status] = contents.split(/\s+/)
   if (status === 'started') {
@@ -69,9 +114,8 @@ try {
   oldContents = init
   const [status] = init.split(/\s+/)
   if (status === 'started') pumpStartTime = Date.now()
-} catch (_) { /* state file may not exist yet */ }
+} catch (_) {}
 
-// Watch for changes and notify Telegram
 fs.watch(stateDir, (type, fname) => {
   if (type === 'change' && fname === stateFile) {
     fs.readFile(path.join(stateDir, stateFile), (err, data) => {
@@ -86,32 +130,55 @@ setInterval(() => {
   applyState(fileContents)
 
   const [status, reason] = fileContents.split(/\s+/)
-  const message = `*Pump Status Changed*\nPump is now *${status}*\nReason: ${reason}`
-  sendMessage(chatId, message)
-    .catch(err => console.error('Notification failed:', err.message))
+  broadcast(`*Pump Status Changed*\nPump is now *${status}*\nReason: ${reason}`)
 }, 10)
 
 // ---- command handling -------------------------------------------------------
 
 async function handleUpdate(update) {
   const msg = update.message
-  if (!msg || !msg.text || String(msg.chat.id) !== String(chatId)) return
+  if (!msg || !msg.text) return
 
+  const chatId = String(msg.chat.id)
   const text = msg.text.trim()
+
+  // /auth is open to anyone
+  if (text.startsWith('/auth')) {
+    const code = text.split(/\s+/)[1] || ''
+    const delta = totp.validate({ token: code, window: 1 })
+    if (delta !== null) {
+      authorizedChats.add(chatId)
+      saveAuth()
+      await sendMessage(chatId, 'Authorized. You will now receive pump status updates.')
+    } else {
+      await sendMessage(chatId, 'Invalid code.')
+    }
+    return
+  }
+
+  // All other commands require authorization — silently ignore unauthorized senders
+  if (!authorizedChats.has(chatId)) return
+
+  if (text === '/deauth') {
+    authorizedChats.delete(chatId)
+    saveAuth()
+    await sendMessage(chatId, 'You have been removed from the authorized list.')
+    return
+  }
 
   if (text === '/reset') {
     try {
       process.kill(getDaemonPid(), 'SIGUSR1')
-      await sendMessage(msg.chat.id, 'Reset signal sent — pump should restart.')
+      await sendMessage(chatId, 'Reset signal sent — pump should restart.')
     } catch (err) {
-      await sendMessage(msg.chat.id, `Reset failed: ${err.message}`)
+      await sendMessage(chatId, `Reset failed: ${err.message}`)
     }
+    return
   }
 
   if (text === '/usage') {
     try {
       process.kill(getDaemonPid(), 'SIGUSR2')
-      // Give the daemon a moment to flush stats to the log
       await new Promise(resolve => setTimeout(resolve, 500))
 
       const log = execSync(`tail -20 "${logFile}"`).toString()
@@ -120,12 +187,13 @@ async function handleUpdate(update) {
         ? matches[matches.length - 1].replace('total_litres: ', '')
         : 'unknown'
 
-      await sendMessage(msg.chat.id,
+      await sendMessage(chatId,
         `*Water Usage*\nTotal litres: ${litres} L\nPump run time: ${currentRuntime()}`
       )
     } catch (err) {
-      await sendMessage(msg.chat.id, `Usage query failed: ${err.message}`)
+      await sendMessage(chatId, `Usage query failed: ${err.message}`)
     }
+    return
   }
 }
 

--- a/notifier/index.js
+++ b/notifier/index.js
@@ -2,55 +2,150 @@
 
 const fs = require('fs')
 const path = require('path')
-const { on } = require('events')
+const { execSync } = require('child_process')
+const axios = require('axios')
+
+const token = process.env.telegramToken
+const chatId = process.env.telegramChatId
+const stateDir = '/run/waterfuse'
 const stateFile = 'waterfuse.state'
-const stateDir = '/var/run/waterfuse'
+const pidFile = path.join(stateDir, 'waterfuse.pid')
+const logFile = '/var/log/waterfuse.log'
 
-let fileContents = ""
-let oldContents = ""
+const api = `https://api.telegram.org/bot${token}`
+let pollOffset = 0
 
-const sendSlack = async function(message) {
-  const { WebClient, LogLevel } = require("@slack/web-api")
-  const channelId = process.env.slackChannel
+let fileContents = ''
+let oldContents = ''
+let pumpStartTime = null   // Date.now() when pump last started
+let accumulatedRunMs = 0   // run time accrued from completed sessions
 
-  const token = process.env.slackToken
-  const client = new WebClient(token, {
-    logLevel: LogLevel.DEBUG
+// ---- helpers ----------------------------------------------------------------
+
+function formatDuration(ms) {
+  const s = Math.floor(ms / 1000)
+  const h = Math.floor(s / 3600)
+  const m = Math.floor((s % 3600) / 60)
+  const sec = s % 60
+  if (h > 0) return `${h}h ${m}m ${sec}s`
+  if (m > 0) return `${m}m ${sec}s`
+  return `${sec}s`
+}
+
+function currentRuntime() {
+  let ms = accumulatedRunMs
+  if (pumpStartTime !== null) ms += Date.now() - pumpStartTime
+  return formatDuration(ms)
+}
+
+function getDaemonPid() {
+  return parseInt(fs.readFileSync(pidFile, 'utf8').trim(), 10)
+}
+
+async function sendMessage(cid, text) {
+  await axios.post(`${api}/sendMessage`, {
+    chat_id: cid,
+    text,
+    parse_mode: 'Markdown'
   })
+}
 
-  const messageArgs = {
-    channel: channelId,
-    text: message
-  }
+// ---- state tracking ---------------------------------------------------------
 
-  try {
-    const retval = client.chat.postMessage(messageArgs)
-  }
-  catch (error) {
-    console.error(error)
-    throw new Error(error)
+function applyState(contents) {
+  const [status] = contents.split(/\s+/)
+  if (status === 'started') {
+    pumpStartTime = Date.now()
+  } else if (status === 'stopped' && pumpStartTime !== null) {
+    accumulatedRunMs += Date.now() - pumpStartTime
+    pumpStartTime = null
   }
 }
 
-// Poll the state file and check for changes, when we get a change
-// we send a message
+// Seed from current state file so run-time tracking survives restarts
+try {
+  const init = fs.readFileSync(path.join(stateDir, stateFile), 'utf8').trim()
+  fileContents = init
+  oldContents = init
+  const [status] = init.split(/\s+/)
+  if (status === 'started') pumpStartTime = Date.now()
+} catch (_) { /* state file may not exist yet */ }
+
+// Watch for changes and notify Telegram
 fs.watch(stateDir, (type, fname) => {
-  if (type === 'change' && fname && fname === stateFile) {
-    fs.readFile(path.join(stateDir,stateFile), (err,data) => {
-      fileContents = data.toString();
+  if (type === 'change' && fname === stateFile) {
+    fs.readFile(path.join(stateDir, stateFile), (err, data) => {
+      if (!err) fileContents = data.toString().trim()
     })
   }
 })
 
-// Now we just keep an eye on the fileContent variable and if it changes
-// we send out a message.  State file has two words in it, started or stopped
-// and a reason code
+setInterval(() => {
+  if (oldContents === fileContents) return
+  oldContents = fileContents
+  applyState(fileContents)
 
-setInterval(async () => {
-  if (oldContents != fileContents) {
-    oldContents = fileContents
-    const content = oldContents.split(/\s/)
-    const message = `*Pump Status Changed*\nPump is now ${content[0]}\nReason: ${content[1]}`
-    await sendSlack(message)
+  const [status, reason] = fileContents.split(/\s+/)
+  const message = `*Pump Status Changed*\nPump is now *${status}*\nReason: ${reason}`
+  sendMessage(chatId, message)
+    .catch(err => console.error('Notification failed:', err.message))
+}, 10)
+
+// ---- command handling -------------------------------------------------------
+
+async function handleUpdate(update) {
+  const msg = update.message
+  if (!msg || !msg.text || String(msg.chat.id) !== String(chatId)) return
+
+  const text = msg.text.trim()
+
+  if (text === '/reset') {
+    try {
+      process.kill(getDaemonPid(), 'SIGUSR1')
+      await sendMessage(msg.chat.id, 'Reset signal sent — pump should restart.')
+    } catch (err) {
+      await sendMessage(msg.chat.id, `Reset failed: ${err.message}`)
+    }
   }
-},10)
+
+  if (text === '/usage') {
+    try {
+      process.kill(getDaemonPid(), 'SIGUSR2')
+      // Give the daemon a moment to flush stats to the log
+      await new Promise(resolve => setTimeout(resolve, 500))
+
+      const log = execSync(`tail -20 "${logFile}"`).toString()
+      const matches = log.match(/total_litres: (\d+)/g)
+      const litres = matches
+        ? matches[matches.length - 1].replace('total_litres: ', '')
+        : 'unknown'
+
+      await sendMessage(msg.chat.id,
+        `*Water Usage*\nTotal litres: ${litres} L\nPump run time: ${currentRuntime()}`
+      )
+    } catch (err) {
+      await sendMessage(msg.chat.id, `Usage query failed: ${err.message}`)
+    }
+  }
+}
+
+// Long-poll loop for incoming commands
+async function poll() {
+  while (true) {
+    try {
+      const res = await axios.get(`${api}/getUpdates`, {
+        params: { offset: pollOffset, timeout: 30 },
+        timeout: 35000
+      })
+      for (const update of res.data.result) {
+        pollOffset = update.update_id + 1
+        handleUpdate(update).catch(err => console.error('Handler error:', err.message))
+      }
+    } catch (err) {
+      console.error('Poll error:', err.message)
+      await new Promise(resolve => setTimeout(resolve, 5000))
+    }
+  }
+}
+
+poll()

--- a/notifier/package-lock.json
+++ b/notifier/package-lock.json
@@ -1,163 +1,364 @@
 {
   "name": "notifier",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@slack/logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-2.0.0.tgz",
-      "integrity": "sha512-OkIJpiU2fz6HOJujhlhfIGrc8hB4ibqtf7nnbJQDerG0BqwZCfmgtK5sWzZ0TkXVRBKD5MpLrTmCYyMxoMCgPw==",
-      "requires": {
-        "@types/node": ">=8.9.0"
-      }
-    },
-    "@slack/types": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.10.0.tgz",
-      "integrity": "sha512-tA7GG7Tj479vojfV3AoxbckalA48aK6giGjNtgH6ihpLwTyHE3fIgRrvt8TWfLwW8X8dyu7vgmAsGLRG7hWWOg=="
-    },
-    "@slack/web-api": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.0.0.tgz",
-      "integrity": "sha512-YD1wqWuzrYPf4RQyD7OnYS5lImUmNWn+G5V6Qt0N97fPYxqhT72YJtRdSnsTc3VkH5R5imKOhYxb+wqI9hiHnA==",
-      "requires": {
-        "@slack/logger": ">=1.0.0 <3.0.0",
-        "@slack/types": "^1.7.0",
-        "@types/is-stream": "^1.1.0",
-        "@types/node": ">=12.0.0",
-        "axios": "^0.21.1",
-        "eventemitter3": "^3.1.0",
-        "form-data": "^2.5.0",
-        "is-stream": "^1.1.0",
-        "p-queue": "^6.6.1",
-        "p-retry": "^4.0.0"
-      }
-    },
-    "@types/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/node": {
-      "version": "14.14.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
-      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
-    },
-    "@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "requires": {
-        "follow-redirects": "^1.10.0"
-      }
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "delayed-stream": {
+  "packages": {
+    "": {
+      "name": "notifier",
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-    },
-    "follow-redirects": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-      "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
-    },
-    "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "mime-db": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
-    },
-    "mime-types": {
-      "version": "2.1.28",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
-      "requires": {
-        "mime-db": "1.45.0"
-      }
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "p-queue": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
-      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-      "requires": {
-        "eventemitter3": "^4.0.4",
-        "p-timeout": "^3.2.0"
-      },
+      "license": "ISC",
       "dependencies": {
-        "eventemitter3": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        "axios": "^1.7.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
       }
     },
-    "p-retry": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
-      "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
-      "requires": {
-        "@types/retry": "^0.12.0",
-        "retry": "^0.12.0"
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
-    "p-timeout": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "requires": {
-        "p-finally": "^1.0.0"
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     }
   }
 }

--- a/notifier/package-lock.json
+++ b/notifier/package-lock.json
@@ -9,7 +9,20 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.7.0"
+        "axios": "^1.7.0",
+        "otpauth": "^9.5.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/agent-base": {
@@ -350,6 +363,18 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/otpauth": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.5.1.tgz",
+      "integrity": "sha512-fJmDAHc8wImfqqqOXIlBvT1dEKrZK0Cmb2VEgScpNTolCz0PHh6ExUZGv4sLtOsWNaHCQlD+rRqaPgnoxFoZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/hectorm/otpauth?sponsor=1"
+      }
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",

--- a/notifier/package.json
+++ b/notifier/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notifier",
   "version": "1.0.0",
-  "description": "Notify waterfuse state changes to Slack",
+  "description": "Notify waterfuse state changes via Telegram",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -9,6 +9,6 @@
   "author": "Adam Donnison <adam@saki.com.au>",
   "license": "ISC",
   "dependencies": {
-    "@slack/web-api": "^6.0.0"
+    "axios": "^1.7.0"
   }
 }

--- a/notifier/package.json
+++ b/notifier/package.json
@@ -9,6 +9,7 @@
   "author": "Adam Donnison <adam@saki.com.au>",
   "license": "ISC",
   "dependencies": {
-    "axios": "^1.7.0"
+    "axios": "^1.7.0",
+    "otpauth": "^9.5.1"
   }
 }


### PR DESCRIPTION
## Summary

- Replaces `@slack/web-api` with direct Telegram Bot API calls via `axios`, dropping 145 packages and eliminating all dependency vulnerabilities
- Adds TOTP-based multi-user authorization: users run `/auth <code>` with a code from their authenticator app; authorized chat IDs are persisted to disk
- Adds bot commands: `/reset` (sends SIGUSR1 to restart pump), `/usage` (reports total litres and pump run time), `/deauth` (self-remove)
- Notifications broadcast to all authorized chats instead of a single hardcoded chat ID
- Forces IPv4 on all Telegram API calls to avoid Node 18+ happy-eyeballs timing out where IPv6 routing to `api.telegram.org` is unavailable
- Fixes empty error messages from `AggregateError` (e.g. `ETIMEDOUT`) with an `errMsg()` helper that falls back to `err.code`

## Environment variables

| Variable | Required | Description |
|----------|----------|-------------|
| `telegramToken` | Yes | Bot token from BotFather |
| `totpSecret` | Yes | Base32 TOTP secret shared with authorized users |
| `authFile` | No | Path to persist authorized chat IDs (default: `/etc/waterfuse/authorized_chats.json`) |

## Generating a TOTP secret

```bash
cd notifier
node -e "const {Secret}=require('otpauth'); const s=new Secret(); console.log(s.base32)"
```

## Test plan

- [ ] Generate TOTP secret and start notifier; confirm `otpauth://` setup URI printed on stdout
- [ ] Add the setup URI to an authenticator app (Google Authenticator, Authy, etc.)
- [ ] `/auth <code>` from two separate Telegram accounts; confirm both receive "Authorized"
- [ ] Trigger a pump state change; confirm both authorized chats receive the notification
- [ ] `/usage` and `/reset` from an authorized chat; confirm correct responses
- [ ] `/reset` from an unauthorized account; confirm silently ignored
- [ ] `/deauth`; confirm chat stops receiving notifications
- [ ] Restart notifier; confirm previously authorized chats reload from `authFile`
- [ ] Confirm no errors on networks without IPv6 routing to `api.telegram.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)